### PR TITLE
Added remember_me functionality

### DIFF
--- a/DependencyInjection/Security/Factory/OAuthFactory.php
+++ b/DependencyInjection/Security/Factory/OAuthFactory.php
@@ -44,6 +44,7 @@ class OAuthFactory extends AbstractFactory
         'use_referer'                    => false,
         'failure_path'                   => null,
         'failure_forward'                => false,
+        'remember_me'                    => false,
     );
 
     /**
@@ -102,7 +103,7 @@ class OAuthFactory extends AbstractFactory
      */
     protected function isRememberMeAware($config)
     {
-        return false;
+        return $config['remember_me'];
     }
 
     /**

--- a/Provider/GoogleProvider.php
+++ b/Provider/GoogleProvider.php
@@ -36,7 +36,8 @@ class GoogleProvider extends Provider
         }
         $expiresAt = time()+$data->expires_in;
 
-        $people = 'https://www.googleapis.com/plus/v1/people/me'
+        //$people = 'https://www.googleapis.com/plus/v1/people/me'
+        $people = 'https://www.googleapis.com/oauth2/v1/userinfo'
             .'?key='.$clientId
             .'&access_token='.$data->access_token;
         $request = new Request(Request::METHOD_GET, $people);
@@ -53,6 +54,7 @@ class GoogleProvider extends Provider
         return 'https://accounts.google.com/o/oauth2/auth'
             .'?client_id='.$clientId
             .'&redirect_uri='.$redirectUrl
+            .'&state=' . urlencode('/profile')
             .'&scope='.urlencode($scope)
             .'&response_type=code';
     }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-EtcpasswdOAuthBundle - [Test] Pfister Edition!
+EtcpasswdOAuthBundle
 ==============
 
 This bundle is is still under development, things might change!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-EtcpasswdOAuthBundle
+EtcpasswdOAuthBundle - [Test] Pfister Edition!
 ==============
 
 This bundle is is still under development, things might change!


### PR DESCRIPTION
Prior to this update, the isRememberMeAware method was hard coded to return false. Now it works off of the security.yml (optional) remember_me  parameter with a default value of false. I have tested this functionality and as long as your user object is setup properly remember_me will work.  
