### PR TITLE
Fix for Symfony v2.1

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -2,13 +2,14 @@
 namespace Etcpasswd\OAuthBundle\Model;
 
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\EquatableInterface;
 
 /**
  * Implementation of a User entity authenticated by this provider
  *
  * @author Marcel Beerta <marcel@etcpasswd.de>
  */
-class User implements UserInterface
+class User implements UserInterface, EquatableInterface
 {
     private $username;
 
@@ -56,7 +57,7 @@ class User implements UserInterface
     /**
      * {@inheritdoc}
      */
-    function equals(UserInterface $user)
+    function isEqualTo(UserInterface $user)
     {
         return (
             $user instanceof User

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -28,6 +28,7 @@
 
         <!-- security listener -->
         <service id="etcpasswd_oauth.authentication.listener.oauth"
+            abstract="true"
             class="%etcpasswd_oauth.authentication.listener.oauth.class%"
             parent="security.authentication.listener.abstract">
                 <argument /><!-- ProviderInterface -->

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name":        "etcpasswd/oauth-bundle",
+    "name":        "andrewbrereton/oauth-bundle",
     "type":        "symfony-bundle",
     "description": "An OAuth firewall for Symfony2",
     "keywords":    ["security", "firewall", "oauth"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name":        "andrewbrereton/oauth-bundle",
+    "name":        "etcpasswd/oauth-bundle",
     "type":        "symfony-bundle",
     "description": "An OAuth firewall for Symfony2",
     "keywords":    ["security", "firewall", "oauth"],


### PR DESCRIPTION
This small change means that EtcpasswordOauthbundle will work with Symfony v2.1 again. It fixes this exception from occurring when executing `php composer.php install`:

```
[Symfony\Component\DependencyInjection\Exception\RuntimeException] 

The definition "etcpasswd_oauth.authentication.listener.oauth" has a reference to an abstract definition "security.authentication.success_handler". Abstract definitions cannot be the target of references.
```
